### PR TITLE
Instruct the plugin not to blend wallpaper images

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
     },
     "Wallpaper": {
         "Preview": "preview.jpg",
+        "Smooth": false,
         "Type": "timed",
         "MetaData": [
             {


### PR DESCRIPTION
This dynamic wallpaper contains a few moving objects, therefore the plugin must be instructed not to perform the cross-fading thing.

Before

![Screenshot_20191104_145119](https://user-images.githubusercontent.com/19847234/68123037-8fe3a380-ff14-11e9-8cfa-0628ae7d87da.png)

After

![Screenshot_20191104_145145](https://user-images.githubusercontent.com/19847234/68123041-91ad6700-ff14-11e9-8321-6ebb357a3a13.png)
